### PR TITLE
Create embeddable live chat widget scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# LiveChat Widget
+
+This project bundles a React-based live chat widget that connects to a Socket.IO backend and can be embedded on any host site.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server serves the widget in library mode so you can iterate on the UI. Use `npm run dev` and visit the printed URL to develop in isolation.
+
+## Building the embeddable script
+
+Run the Vite production build to generate a single IIFE bundle at `dist/livechat-widget.js`:
+
+```bash
+npm run build
+```
+
+The bundle exposes a global initializer under `window.LiveChatWidget.init(options)`. Calling the initializer renders the floating widget, connects it to your Socket.IO server, and returns an object with the active Socket.IO client and a `destroy()` helper.
+
+### Initialization options
+
+| Option | Type | Required | Description |
+| ------ | ---- | -------- | ----------- |
+| `serverUrl` | `string` | ✅ | Base URL of your Socket.IO backend (e.g. `https://your-app.example.com`). |
+| `room` | `string` | ❌ | Optional room/channel identifier to join after connecting. |
+| `title` | `string` | ❌ | Custom header text for the widget. |
+| `container` | `HTMLElement` | ❌ | Use an existing DOM node instead of the default floating mount. |
+| `socketOptions` | `SocketOptions` | ❌ | Additional options forwarded to `socket.io-client`'s `io()` factory. |
+
+The initializer returns:
+
+```ts
+const { socket, destroy } = window.LiveChatWidget.init({
+  serverUrl: "https://your-app.example.com",
+  room: "support",
+  title: "Need help?"
+});
+```
+
+Call `destroy()` to unmount the React tree, disconnect the socket, and remove the injected DOM node when you no longer need the widget.
+
+## Embedding in a host page
+
+1. Copy `dist/livechat-widget.js` to a location your site can serve.
+2. Load it with a standard `<script>` tag.
+3. Call the initializer with your configuration.
+
+```html
+<script src="/path/to/livechat-widget.js"></script>
+<script>
+  window.LiveChatWidget.init({
+    serverUrl: "https://your-app.example.com",
+    room: "marketing",
+    title: "Chat with us"
+  });
+</script>
+```
+
+The widget floats in the bottom-right corner and includes styling that isolates it from most host page layouts.
+
+## Demo page
+
+A static page at `demo/index.html` references the built bundle and calls the initializer for manual testing. After running `npm run build`, open the file directly in a browser or serve it via a simple static server to verify the widget end-to-end.
+
+## Socket events
+
+The widget expects a Socket.IO backend that supports the following events:
+
+- `message`: Emitted by both client and server. Payload shape `{ text: string, room?: string, role?: "user" | "agent" }`.
+- `typing`: Emitted by both client and server. Payload shape `{ isTyping: boolean, room?: string, role?: "user" | "agent" }`.
+- `join` / `leave`: Emitted by the client when `room` is provided to subscribe/unsubscribe from a channel.
+
+Adjust the event names in `widget/src/index.tsx` to match your backend if needed.
+
+## License
+
+MIT

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LiveChat Widget Demo</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(135deg, #f1f5f9, #e2e8f0);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #0f172a;
+      }
+
+      .demo-card {
+        max-width: 420px;
+        padding: 2.5rem;
+        border-radius: 1rem;
+        background: white;
+        box-shadow: 0 30px 50px rgba(15, 23, 42, 0.15);
+      }
+
+      code {
+        background: rgba(148, 163, 184, 0.15);
+        padding: 0.15rem 0.4rem;
+        border-radius: 0.3rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-card">
+      <h1>LiveChat Widget Demo</h1>
+      <p>
+        Build the widget with <code>npm run build</code>, then reload this page to see the
+        floating chat UI injected via <code>window.LiveChatWidget.init()</code>.
+      </p>
+      <p>
+        Open the developer tools console to see connection logs from the Socket.IO client.
+      </p>
+    </div>
+
+    <script src="../dist/livechat-widget.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        if (!window.LiveChatWidget) {
+          console.error("LiveChatWidget global is not available. Did you run npm run build?");
+          return;
+        }
+
+        window.LiveChatWidget.init({
+          serverUrl: "http://localhost:3000",
+          room: "demo-room",
+          title: "Ask our team",
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "livechat-widget",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.65",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["widget/src"],
+  "references": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "widget/src/index.tsx"),
+      name: "LiveChatWidget",
+      fileName: () => "livechat-widget.js",
+      formats: ["iife"],
+    },
+    rollupOptions: {
+      external: [],
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: true,
+    minify: true,
+  },
+});

--- a/widget/src/index.tsx
+++ b/widget/src/index.tsx
@@ -1,0 +1,246 @@
+import React, { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { io } from "socket.io-client";
+import type { Socket } from "socket.io-client";
+import "./styles.css";
+
+type Role = "user" | "agent" | "system";
+
+type ChatMessage = {
+  id: string;
+  role: Role;
+  text: string;
+  timestamp: number;
+};
+
+type SocketMessagePayload = {
+  id?: string;
+  role?: Role;
+  text: string;
+  timestamp?: number;
+  room?: string;
+};
+
+type TypingPayload = {
+  role?: Role;
+  isTyping: boolean;
+  room?: string;
+};
+
+type LiveChatWidgetOptions = {
+  /**
+   * Socket.IO server URL (e.g. https://your-app.example.com)
+   */
+  serverUrl: string;
+  /**
+   * Optional room or channel identifier to join.
+   */
+  room?: string;
+  /**
+   * Optional element to use as the mounting container.
+   * The widget will append a new element when not provided.
+   */
+  container?: HTMLElement;
+  /**
+   * Text shown in the header of the widget.
+   */
+  title?: string;
+  /**
+   * Additional Socket.IO client options.
+   */
+  socketOptions?: Parameters<typeof io>[1];
+};
+
+type ChatWidgetProps = {
+  socket: Socket;
+  title?: string;
+  room?: string;
+};
+
+const generateId = () => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const ChatWidget: React.FC<ChatWidgetProps> = ({ socket, title = "Live Chat", room }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isConnected, setIsConnected] = useState(socket.connected);
+  const [agentTyping, setAgentTyping] = useState(false);
+
+  useEffect(() => {
+    const handleConnect = () => setIsConnected(true);
+    const handleDisconnect = () => setIsConnected(false);
+
+    socket.on("connect", handleConnect);
+    socket.on("disconnect", handleDisconnect);
+
+    if (room) {
+      socket.emit("join", { room });
+    }
+
+    return () => {
+      socket.off("connect", handleConnect);
+      socket.off("disconnect", handleDisconnect);
+      if (room) {
+        socket.emit("leave", { room });
+      }
+    };
+  }, [room, socket]);
+
+  useEffect(() => {
+    const handleMessage = (payload: SocketMessagePayload) => {
+      if (payload.room && room && payload.room !== room) {
+        return;
+      }
+
+      const message: ChatMessage = {
+        id: payload.id ?? generateId(),
+        role: payload.role ?? "agent",
+        text: payload.text,
+        timestamp: payload.timestamp ?? Date.now(),
+      };
+
+      setMessages((prev) => [...prev, message]);
+    };
+
+    let typingTimeout: number | undefined;
+
+    const handleTyping = (payload: TypingPayload) => {
+      if (payload.room && room && payload.room !== room) {
+        return;
+      }
+
+      const role = payload.role ?? "agent";
+      if (role === "user") {
+        return;
+      }
+
+      setAgentTyping(payload.isTyping);
+
+      if (payload.isTyping) {
+        window.clearTimeout(typingTimeout);
+        typingTimeout = window.setTimeout(() => setAgentTyping(false), 2000);
+      } else {
+        window.clearTimeout(typingTimeout);
+      }
+    };
+
+    socket.on("message", handleMessage);
+    socket.on("typing", handleTyping);
+
+    return () => {
+      socket.off("message", handleMessage);
+      socket.off("typing", handleTyping);
+      window.clearTimeout(typingTimeout);
+    };
+  }, [room, socket]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || !isConnected) {
+      return;
+    }
+
+    const outgoing: ChatMessage = {
+      id: generateId(),
+      role: "user",
+      text: trimmed,
+      timestamp: Date.now(),
+    };
+
+    setMessages((prev) => [...prev, outgoing]);
+    socket.emit("message", { text: trimmed, room, role: "user" });
+    socket.emit("typing", { isTyping: false, room, role: "user" });
+    setInput("");
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setInput(value);
+    socket.emit("typing", { isTyping: value.trim().length > 0, room, role: "user" });
+  };
+
+  return (
+    <div className="lc-widget-container">
+      <header className="lc-widget-header">
+        <h1 className="lc-widget-title">{title}</h1>
+        <span>{isConnected ? "● Online" : "○ Offline"}</span>
+      </header>
+      <div className="lc-widget-body">
+        {messages.map((message) => (
+          <div key={message.id} className={`lc-message-row ${message.role === "user" ? "user" : "agent"}`}>
+            <div className="lc-message-bubble">{message.text}</div>
+          </div>
+        ))}
+      </div>
+      {agentTyping && <div className="lc-typing-indicator">Support is typing…</div>}
+      <div className="lc-input-bar">
+        <form className="lc-input-form" onSubmit={handleSubmit}>
+          <input
+            className="lc-input-field"
+            value={input}
+            onChange={handleInputChange}
+            placeholder={isConnected ? "Type your message" : "Connecting…"}
+            disabled={!isConnected}
+          />
+          <button className="lc-send-button" type="submit" disabled={!isConnected || input.trim().length === 0}>
+            Send
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export function createLiveChatWidget(options: LiveChatWidgetOptions) {
+  if (typeof document === "undefined") {
+    throw new Error("createLiveChatWidget can only be used in a browser environment");
+  }
+
+  const { container, serverUrl, socketOptions, ...rest } = options;
+
+  const mount = container ?? document.createElement("div");
+  if (!container) {
+    mount.classList.add("lc-widget-host");
+    document.body.appendChild(mount);
+  }
+
+  const socket = io(serverUrl, {
+    transports: ["websocket", "polling"],
+    autoConnect: true,
+    ...socketOptions,
+  });
+
+  const root = createRoot(mount);
+  root.render(
+    <React.StrictMode>
+      <ChatWidget socket={socket} {...rest} />
+    </React.StrictMode>
+  );
+
+  return {
+    destroy: () => {
+      root.unmount();
+      socket.disconnect();
+      if (!container && mount.parentNode) {
+        mount.parentNode.removeChild(mount);
+      }
+    },
+    socket,
+  };
+}
+
+declare global {
+  interface Window {
+    LiveChatWidget?: {
+      init: typeof createLiveChatWidget;
+    };
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.LiveChatWidget = {
+    init: createLiveChatWidget,
+  };
+}
+
+export type { LiveChatWidgetOptions };

--- a/widget/src/styles.css
+++ b/widget/src/styles.css
@@ -1,0 +1,131 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.lc-widget-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 22rem;
+  max-width: calc(100vw - 3rem);
+  height: 30rem;
+  max-height: calc(100vh - 3rem);
+  z-index: 2147483647;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  border-radius: 1rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.lc-widget-header {
+  background: linear-gradient(90deg, #2563eb, #7c3aed);
+  color: white;
+  padding: 0.9rem 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.lc-widget-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.lc-widget-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  overflow-y: auto;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.lc-message-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-width: 85%;
+}
+
+.lc-message-row.user {
+  align-self: flex-end;
+  text-align: right;
+}
+
+.lc-message-bubble {
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.9rem;
+  line-height: 1.4;
+  font-size: 0.95rem;
+  color: #0f172a;
+  background: white;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.lc-message-row.user .lc-message-bubble {
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.9), rgba(124, 58, 237, 0.9));
+  color: white;
+  border: none;
+}
+
+.lc-input-bar {
+  padding: 0.9rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.lc-input-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.lc-input-field {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.55rem 0.9rem;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lc-input-field:focus {
+  border-color: rgba(59, 130, 246, 0.8);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.lc-send-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  background: linear-gradient(90deg, #2563eb, #7c3aed);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.lc-send-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.lc-typing-indicator {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+  padding: 0 1rem 0.8rem;
+}
+
+@media (max-width: 600px) {
+  .lc-widget-container {
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    max-width: none;
+  }
+}

--- a/widget/src/vite-env.d.ts
+++ b/widget/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- scaffold a Socket.IO-powered React chat widget and expose an initializer on the window object
- configure Vite to build a single IIFE bundle with the widget UI styling and assets
- add a static demo page and README documentation for embedding and configuration

## Testing
- npm install *(fails: 403 Forbidden fetching packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d805d203f08322870b56d635d77f46